### PR TITLE
Only display insulin type in pump selection if it can be administered

### DIFF
--- a/Loop/Managers/DeviceDataManager.swift
+++ b/Loop/Managers/DeviceDataManager.swift
@@ -72,6 +72,13 @@ final class DeviceDataManager {
         if !FeatureFlags.afrezzaInsulinModelEnabled {
             allowed.remove(.afrezza)
         }
+
+        for insulinType in InsulinType.allCases {
+            if !insulinType.pumpAdministerable {
+                allowed.remove(insulinType)
+            }
+        }
+
         return allowed
     }()
 


### PR DESCRIPTION
This PR adds UI logic to ensure Afrezza (and other insulin types that cannot be administered by an insulin pump) do not appear as options when setting up an insulin pump.